### PR TITLE
adapted GHA to work with bun, works with prebuilt astro action

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# TODO: do we need all this, could make it slimmer?
 permissions:
   contents: read
   pages: write
@@ -24,6 +25,7 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+#TODO: do we need env?
 env:
   BUILD_PATH: "." # default value when not using subfolders
   # BUILD_PATH: subfolder
@@ -35,47 +37,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Detect package manager
-        id: detect-package-manager
-        run: |
-          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
-            echo "manager=yarn" >> $GITHUB_OUTPUT
-            echo "command=install" >> $GITHUB_OUTPUT
-            echo "runner=yarn" >> $GITHUB_OUTPUT
-            echo "lockfile=yarn.lock" >> $GITHUB_OUTPUT
-            exit 0
-          elif [ -f "${{ github.workspace }}/package.json" ]; then
-            echo "manager=npm" >> $GITHUB_OUTPUT
-            echo "command=ci" >> $GITHUB_OUTPUT
-            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
-            echo "lockfile=package-lock.json" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "Unable to determine package manager"
-            exit 1
-          fi
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Install, build, and upload your site
+        uses: withastro/action@v4
         with:
-          node-version: "20"
-          cache: ${{ steps.detect-package-manager.outputs.manager }}
-          cache-dependency-path: ${{ env.BUILD_PATH }}/${{ steps.detect-package-manager.outputs.lockfile }}
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v5
-      - name: Install dependencies
-        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
-        working-directory: ${{ env.BUILD_PATH }}
-      - name: Build with Astro
-        run: |
-          ${{ steps.detect-package-manager.outputs.runner }} astro build \
-            --site "${{ steps.pages.outputs.origin }}" \
-            --base "${{ steps.pages.outputs.base_path }}"
-        working-directory: ${{ env.BUILD_PATH }}
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ${{ env.BUILD_PATH }}/dist
+          node-version: 20 
+          # can also do without the package-manager, will detect it
+          package-manager: bun@latest
 
   deploy:
     environment:


### PR DESCRIPTION
The other two commits accidentally already got merged into the main branch, but they all are to fix #2 

I wasn't quite sure what you meant with "adapt GHA" but I put on my critical thinking cap and thought you probably meant adapt it to the new runtime (bun). So I did that, but also thought I would try out using the pre-built `withastro/action@v4` which is also referenced in the [astro documentation](https://docs.astro.build/en/guides/deploy/github/). 
 